### PR TITLE
Go back to top of document if no hash

### DIFF
--- a/pages/scripts/clipboard.js
+++ b/pages/scripts/clipboard.js
@@ -51,9 +51,7 @@ window.addEventListener("popstate", scrollToCurrentHash);
 document.addEventListener("DOMContentLoaded", scrollToCurrentHash);
 function scrollToCurrentHash(e) {
   const u = new URL(location.href);
-  const hash = u.hash.slice(1);
-  if (!hash) return;
-
+  const hash = u.hash.slice(1) || 'header';
   const elem = document.querySelector(`#${hash}`);
   elem.scrollIntoView({block: 'start'});
 }


### PR DESCRIPTION
I found trying to navigate the docs difficult because I'd be in the table of contents at the top of an API doc. I'd click a function then click back but it didn't go back to where I was. This not perfect since it not technically "where I was" but it's closer than not going anywhere which is what it does now.

wdyt?